### PR TITLE
Change 'zone_blob' key to 'blob' in create server.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Christopher MacGown <ignoti+github@gmail.com>
 Dan Wendlandt <dan@nicira.com>
 Dean Troyer <dtroyer@gmail.com>
 Ed Leafe <ed@leafe.com>
+Edouard Thuleau <edouard1.thuleau@orange.com>
 Eldar Nugaev <eldr@ya.ru>
 Gabriel Hurley <gabriel@strikeawe.com>
 Gaurav Gupta <gaurav@denali-systems.com>

--- a/novaclient/base.py
+++ b/novaclient/base.py
@@ -171,7 +171,7 @@ class BootingManagerWithFind(ManagerWithFind):
         if reservation_id:
             body["server"]["reservation_id"] = reservation_id
         if zone_blob:
-            body["server"]["zone_blob"] = zone_blob
+            body["server"]["blob"] = zone_blob
 
         if not min_count:
             min_count = 1

--- a/novaclient/v1_0/base.py
+++ b/novaclient/v1_0/base.py
@@ -71,7 +71,7 @@ class BootingManagerWithFind(base.ManagerWithFind):
         if reservation_id:
             body["server"]["reservation_id"] = reservation_id
         if zone_blob:
-            body["server"]["zone_blob"] = zone_blob
+            body["server"]["blob"] = zone_blob
 
         if not min_count:
             min_count = 1

--- a/novaclient/v1_1/base.py
+++ b/novaclient/v1_1/base.py
@@ -71,7 +71,7 @@ class BootingManagerWithFind(base.ManagerWithFind):
         if reservation_id:
             body["server"]["reservation_id"] = reservation_id
         if zone_blob:
-            body["server"]["zone_blob"] = zone_blob
+            body["server"]["blob"] = zone_blob
         if key_name:
             body["server"]["key_name"] = key_name
 


### PR DESCRIPTION
Fixes bug 893183

The OSAPI looks for key 'blob' to check if a build plan
is associated to a create request server. But the
novaclient uses the key 'zone_blob'.
