### PR TITLE
Adding raise into the main() of the shell function. When the version is ...

### DIFF
--- a/novaclient/shell.py
+++ b/novaclient/shell.py
@@ -361,4 +361,5 @@ def main():
             raise  # dump stack.
         else:
             print >> sys.stderr, e
+            raise
         sys.exit(1)


### PR DESCRIPTION
...omitted, it will throw a UnsupportedVersion exception, which has no messages and the "print >> sys.stderr, e" doesn't show anything telling the user what was the problem. Errors should never pass silently.
