### PR TITLE
Update prettytable requirement for flexibility

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -1,4 +1,4 @@
 argparse
 httplib2
-prettytable==0.6
+prettytable>0.6
 simplejson


### PR DESCRIPTION
Requiring 0.6 broke when 0.6.1 was released (it seemingly chooses 0.6.1 over 0.6 with == 0.6)
