### PR TITLE
Hey I just added support for an additional ssh param --extra-opts

### DIFF
--- a/novaclient/v1_1/shell.py
+++ b/novaclient/v1_1/shell.py
@@ -2120,6 +2120,10 @@ def do_credentials(cs, _args):
     dest='identity',
     help='Private key file, same as the -i option to the ssh command.',
     default='')
+@utils.arg('--extra-opts',
+    dest='extra',
+    help='Extra options to pass to ssh. see: man ssh',
+    default='')
 def do_ssh(cs, args):
     """SSH into a server."""
     addresses = _find_server(cs, args.server).addresses
@@ -2138,10 +2142,11 @@ def do_ssh(cs, args):
             break
 
     identity = '-i %s' % args.identity if len(args.identity) else ''
+    extra = args.extra if len(args.extra) else ''
 
     if ip_address:
-        os.system("ssh -%d -p%d %s %s@%s" % (version, args.port, identity,
-                                             args.login, ip_address))
+        os.system("ssh -%d -p%d %s %s@%s %s" % (version, args.port, identity,
+                                             args.login, ip_address, extra))
     else:
         pretty_version = "IPv%d" % version
         print "ERROR: No %s %s address found." % (address_type,


### PR DESCRIPTION
...command execution and advanced ssh options like portforwarding and connection sharing.

Could you consider adding this to the master... I really find it useful to do advanced ssh options... I tested my code with a Rackspace instance... I was able to pass all ssh flags that I needed inclosed in a string.

Usage:

```nova ssh fe55adc9-cb1e-44a4-bd36-6a537b238172 --extra-opts='-NfnMS ~/.ssh/master-fe55adc9-cb1e-44a4-bd36-6a537b238172'

```

I figure that's as complex as most users need.

I also ran "run_tests.sh" which reported ok on all checks.

Thanks,

Nick Shobe
```
