### PR TITLE
Python3 support

### DIFF
--- a/novaclient/base.py
+++ b/novaclient/base.py
@@ -103,7 +103,7 @@ class Manager(utils.HookableMixin):
         cache_dir = os.path.expanduser(os.path.join(base_dir, uniqifier))
 
         try:
-            os.makedirs(cache_dir, 0755)
+            os.makedirs(cache_dir, 0o755)
         except OSError:
             # NOTE(kiall): This is typicaly either permission denied while
             #              attempting to create the directory, or the directory

--- a/novaclient/client.py
+++ b/novaclient/client.py
@@ -213,7 +213,7 @@ class HTTPClient(object):
             resp, body = self._time_request(self.management_url + url, method,
                                             **kwargs)
             return resp, body
-        except exceptions.Unauthorized, ex:
+        except exceptions.Unauthorized as e:
             try:
                 self.authenticate()
                 kwargs['headers']['X-Auth-Token'] = self.auth_token
@@ -221,7 +221,7 @@ class HTTPClient(object):
                                                 method, **kwargs)
                 return resp, body
             except exceptions.Unauthorized:
-                raise ex
+                raise e
 
     def get(self, url, **kwargs):
         return self._cs_request(url, 'GET', **kwargs)
@@ -259,13 +259,13 @@ class HTTPClient(object):
                 self.management_url = management_url.rstrip('/')
                 return None
             except exceptions.AmbiguousEndpoints:
-                print "Found more than one valid endpoint. Use a more " \
-                      "restrictive filter"
+                print("Found more than one valid endpoint. Use a more "
+                      "restrictive filter")
                 raise
             except KeyError:
                 raise exceptions.AuthorizationFailure()
             except exceptions.EndpointNotFound:
-                print "Could not find any suitable endpoint. Correct region?"
+                print("Could not find any suitable endpoint. Correct region?")
                 raise
 
         elif resp.status_code == 305:

--- a/novaclient/openstack/common/setup.py
+++ b/novaclient/openstack/common/setup.py
@@ -176,7 +176,7 @@ def _get_git_post_version():
             revno = len(out.split("\n"))
             sha = _run_shell_command("git describe --always")
         else:
-            tag_infos = tag_info.split("-")
+            tag_infos = str(tag_info).split("-")
             base_version = "-".join(tag_infos[:-2])
             (revno, sha) = tag_infos[-2:]
         return "%s.%s.%s" % (base_version, revno, sha)
@@ -277,7 +277,7 @@ def get_cmdclass():
 
         class LocalBuildDoc(BuildDoc):
             def generate_autoindex(self):
-                print "**Autodocumenting from %s" % os.path.abspath(os.curdir)
+                print("**Autodocumenting from %s" % os.path.abspath(os.curdir))
                 modules = {}
                 option_dict = self.distribution.get_option_dict('build_sphinx')
                 source_dir = os.path.join(option_dict['source_dir'][1], 'api')
@@ -302,7 +302,7 @@ def get_cmdclass():
                         values = dict(module=module, heading=heading,
                                       underline=underline)
 
-                        print "Generating %s" % output_filename
+                        print("Generating %s" % output_filename)
                         with open(output_filename, 'w') as output_file:
                             output_file.write(_rst_template % values)
                         autoindex.write("   %s.rst\n" % module)

--- a/novaclient/shell.py
+++ b/novaclient/shell.py
@@ -708,7 +708,7 @@ class OpenStackComputeShell(object):
 
         commands.remove('bash-completion')
         commands.remove('bash_completion')
-        print ' '.join(commands | options)
+        print(' '.join(commands | options))
 
     @utils.arg('command', metavar='<subcommand>', nargs='?',
                     help='Display help for <subcommand>')
@@ -738,9 +738,9 @@ def main():
     try:
         OpenStackComputeShell().main(sys.argv[1:])
 
-    except Exception, e:
+    except Exception as e:
         logger.debug(e, exc_info=1)
-        print >> sys.stderr, "ERROR: %s" % unicode(e)
+        print("ERROR: %s" % unicode(e), file=sys.stderr)
         sys.exit(1)
 
 

--- a/novaclient/utils.py
+++ b/novaclient/utils.py
@@ -162,9 +162,9 @@ def print_list(objs, fields, formatters={}, sortby_index=0):
         pt.add_row(row)
 
     if sortby is not None:
-        print pt.get_string(sortby=sortby)
+        print(pt.get_string(sortby=sortby))
     else:
-        print pt.get_string()
+        print(pt.get_string())
 
 
 def print_dict(d, dict_property="Property"):
@@ -184,7 +184,7 @@ def print_dict(d, dict_property="Property"):
                 col1 = ''
         else:
             pt.add_row([k, v])
-    print pt.get_string()
+    print(pt.get_string())
 
 
 def find_resource(manager, name_or_id):

--- a/novaclient/v1_1/shell.py
+++ b/novaclient/v1_1/shell.py
@@ -101,7 +101,7 @@ def _boot(cs, args, reservation_id=None, min_count=None, max_count=None):
         dst, src = f.split('=', 1)
         try:
             files[dst] = open(src)
-        except IOError, e:
+        except IOError as e:
             raise exceptions.CommandError("Can't open '%s': %s" % (src, e))
 
     # use the os-keypair extension
@@ -112,7 +112,7 @@ def _boot(cs, args, reservation_id=None, min_count=None, max_count=None):
     if args.user_data:
         try:
             userdata = open(args.user_data)
-        except IOError, e:
+        except IOError as e:
             raise exceptions.CommandError("Can't open '%s': %s" %
                                           (args.user_data, e))
     else:
@@ -357,11 +357,11 @@ def _poll_for_status(poll_fn, obj_id, action, final_ok_states,
         if status in final_ok_states:
             if not silent:
                 print_progress(100)
-                print "\nFinished"
+                print("\nFinished")
             break
         elif status == "error":
             if not silent:
-                print "\nError %(action)s instance" % locals()
+                print("\nError %(action)s instance" % locals())
             break
 
         if not silent:
@@ -518,7 +518,7 @@ def do_flavor_access_list(cs, args):
 
     try:
         access_list = cs.flavor_access.list(**kwargs)
-    except NotImplementedError, e:
+    except NotImplementedError as e:
         raise exceptions.CommandError("%s" % str(e))
 
     columns = ['Flavor_ID', 'Tenant_ID']
@@ -1274,8 +1274,8 @@ def do_delete(cs, args):
     for server in args.server:
         try:
             _find_server(cs, server).delete()
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
 
 
 def _find_server(cs, server):
@@ -1606,7 +1606,7 @@ def do_get_password(cs, args):
     """Get password for a server."""
     server = _find_server(cs, args.server)
     data = server.get_password(args.private_key)
-    print data
+    print(data)
 
 
 @utils.arg('server', metavar='<server>', help='Name or ID of server.')
@@ -1629,7 +1629,7 @@ def do_console_log(cs, args):
     """Get console log output of a server."""
     server = _find_server(cs, args.server)
     data = server.get_console_output(length=args.length)
-    print data
+    print(data)
 
 
 @utils.arg('server', metavar='<server>', help='Name or ID of server.')
@@ -2016,7 +2016,7 @@ def do_keypair_add(cs, args):
         try:
             with open(os.path.expanduser(pub_key)) as f:
                 pub_key = f.read()
-        except IOError, e:
+        except IOError as e:
             raise exceptions.CommandError("Can't open or read '%s': %s" %
                                                           (pub_key, e))
 
@@ -2024,7 +2024,7 @@ def do_keypair_add(cs, args):
 
     if not pub_key:
         private_key = keypair.private_key
-        print private_key
+        print(private_key)
 
 
 @utils.arg('name', metavar='<name>', help='Keypair name to delete.')
@@ -2095,8 +2095,8 @@ def do_usage_list(cs, args):
 
     usage_list = cs.usage.list(start, end, detailed=True)
 
-    print "Usage from %s to %s:" % (start.strftime(dateformat),
-                                    end.strftime(dateformat))
+    print("Usage from %s to %s:" % (start.strftime(dateformat),
+                                    end.strftime(dateformat)))
 
     for usage in usage_list:
         simplify_usage(usage)
@@ -2143,14 +2143,14 @@ def do_usage(cs, args):
     else:
         usage = cs.usage.get(cs.client.tenant_id, start, end)
 
-    print "Usage from %s to %s:" % (start.strftime(dateformat),
-                                    end.strftime(dateformat))
+    print("Usage from %s to %s:" % (start.strftime(dateformat),
+                                    end.strftime(dateformat)))
 
     if getattr(usage, 'total_vcpus_usage', None):
         simplify_usage(usage)
         utils.print_list([usage], rows)
     else:
-        print 'None'
+        print('None')
 
 
 @utils.arg('pk_filename',
@@ -2179,13 +2179,13 @@ def do_x509_create_cert(cs, args):
         old_umask = os.umask(0o377)
         with open(args.pk_filename, 'w') as private_key:
             private_key.write(certs.private_key)
-            print "Wrote private key to %s" % args.pk_filename
+            print("Wrote private key to %s" % args.pk_filename)
     finally:
         os.umask(old_umask)
 
     with open(args.cert_filename, 'w') as cert:
         cert.write(certs.data)
-        print "Wrote x509 certificate to %s" % args.cert_filename
+        print("Wrote x509 certificate to %s" % args.cert_filename)
 
 
 @utils.arg('filename',
@@ -2202,7 +2202,7 @@ def do_x509_get_root_cert(cs, args):
     with open(args.filename, 'w') as cert:
         cacert = cs.certs.get()
         cert.write(cacert.data)
-        print "Wrote x509 root cert to %s" % args.filename
+        print("Wrote x509 root cert to %s" % args.filename)
 
 
 @utils.arg('--hypervisor', metavar='<hypervisor>', default=None,
@@ -2271,7 +2271,7 @@ def do_aggregate_create(cs, args):
 def do_aggregate_delete(cs, args):
     """Delete the aggregate by its id."""
     cs.aggregates.delete(args.id)
-    print "Aggregate %s has been successfully deleted." % args.id
+    print("Aggregate %s has been successfully deleted." % args.id)
 
 
 @utils.arg('id', metavar='<id>', help='Aggregate id to update.')
@@ -2288,7 +2288,7 @@ def do_aggregate_update(cs, args):
         updates["availability_zone"] = args.availability_zone
 
     aggregate = cs.aggregates.update(args.id, updates)
-    print "Aggregate %s has been successfully updated." % args.id
+    print("Aggregate %s has been successfully updated." % args.id)
     _print_aggregate_details(aggregate)
 
 
@@ -2303,7 +2303,7 @@ def do_aggregate_set_metadata(cs, args):
     """Update the metadata associated with the aggregate."""
     metadata = _extract_metadata(args)
     aggregate = cs.aggregates.set_metadata(args.id, metadata)
-    print "Aggregate %s has been successfully updated." % args.id
+    print("Aggregate %s has been successfully updated." % args.id)
     _print_aggregate_details(aggregate)
 
 
@@ -2312,7 +2312,7 @@ def do_aggregate_set_metadata(cs, args):
 def do_aggregate_add_host(cs, args):
     """Add the host to the specified aggregate."""
     aggregate = cs.aggregates.add_host(args.id, args.host)
-    print "Aggregate %s has been successfully updated." % args.id
+    print("Aggregate %s has been successfully updated." % args.id)
     _print_aggregate_details(aggregate)
 
 
@@ -2322,7 +2322,7 @@ def do_aggregate_add_host(cs, args):
 def do_aggregate_remove_host(cs, args):
     """Remove the specified host from the specified aggregate."""
     aggregate = cs.aggregates.remove_host(args.id, args.host)
-    print "Aggregate %s has been successfully updated." % args.id
+    print("Aggregate %s has been successfully updated." % args.id)
     _print_aggregate_details(aggregate)
 
 
@@ -2478,13 +2478,13 @@ def do_host_action(cs, args):
 def do_coverage_start(cs, args):
     """Start Nova coverage reporting"""
     cs.coverage.start(combine=args.combine)
-    print "Coverage collection started"
+    print("Coverage collection started")
 
 
 def do_coverage_stop(cs, args):
     """Stop Nova coverage reporting"""
     out = cs.coverage.stop()
-    print "Coverage data file path: %s" % out[-1]['path']
+    print("Coverage data file path: %s" % out[-1]['path'])
 
 
 @utils.arg('filename', metavar='<filename>', help='report filename')
@@ -2504,7 +2504,7 @@ def do_coverage_report(cs, args):
         raise exceptions.CommandError("--html and --xml must not be "
                                       "specified together.")
     cov = cs.coverage.report(args.filename, xml=args.xml, html=args.html)
-    print "Report path: %s" % cov[-1]['path']
+    print("Report path: %s" % cov[-1]['path'])
 
 
 @utils.arg('--matching', metavar='<hostname>', default=None,
@@ -2640,8 +2640,8 @@ def do_ssh(cs, args):
     version = 6 if args.ipv6 else 4
 
     if address_type not in addresses:
-        print "ERROR: No %s addresses found for '%s'." % (address_type,
-                                                          args.server)
+        print("ERROR: No %s addresses found for '%s'." % (address_type,
+                                                          args.server))
         return
 
     ip_address = None
@@ -2658,8 +2658,8 @@ def do_ssh(cs, args):
                                                 args.extra))
     else:
         pretty_version = "IPv%d" % version
-        print "ERROR: No %s %s address found." % (address_type,
-                                                  pretty_version)
+        print("ERROR: No %s %s address found." % (address_type,
+                                                  pretty_version))
         return
 
 
@@ -2961,7 +2961,7 @@ def do_availability_zone_list(cs, _args):
     """List all the availability zones."""
     try:
         availability_zones = cs.availability_zones.list()
-    except exceptions.Forbidden, e:  # policy doesn't allow probably
+    except exceptions.Forbidden as e:  # policy doesn't allow probably
         try:
             availability_zones = cs.availability_zones.list(detailed=False)
         except:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -57,9 +57,9 @@ class FakeClient(object):
             try:
                 assert entry[2] == body
             except AssertionError:
-                print entry[2]
-                print "!="
-                print body
+                print(entry[2])
+                print("!=")
+                print(body)
                 raise
 
         self.client.callstack = []

--- a/tests/v1_1/contrib/test_tenant_networks.py
+++ b/tests/v1_1/contrib/test_tenant_networks.py
@@ -38,7 +38,7 @@ class TenantNetworkExtensionTests(utils.TestCase):
     def test_get_tenant_network(self):
         net = cs.tenant_networks.get(1)
         cs.assert_called('GET', '/os-tenant-networks/1')
-        print net
+        print(net)
 
     def test_create_tenant_networks(self):
         cs.tenant_networks.create(label="net",

--- a/tools/install_venv.py
+++ b/tools/install_venv.py
@@ -37,7 +37,7 @@ PY_VERSION = "python%s.%s" % (sys.version_info[0], sys.version_info[1])
 
 
 def die(message, *args):
-    print >> sys.stderr, message % args
+    print(message % args, file=sys.stderr)
     sys.exit(1)
 
 
@@ -77,12 +77,12 @@ class Distro(object):
             return
 
         if self.check_cmd('easy_install'):
-            print 'Installing virtualenv via easy_install...',
+            print('Installing virtualenv via easy_install...')
             if run_command(['easy_install', 'virtualenv']):
-                print 'Succeeded'
+                print('Succeeded')
                 return
             else:
-                print 'Failed'
+                print('Failed')
 
         die('ERROR: virtualenv not found.\n\nDevelopment'
             ' requires virtualenv, please install it using your'
@@ -162,17 +162,17 @@ def create_virtualenv(venv=VENV, no_site_packages=True):
     """Creates the virtual environment and installs PIP only into the
     virtual environment
     """
-    print 'Creating venv...',
+    print('Creating venv...')
     if no_site_packages:
         run_command(['virtualenv', '-q', '--no-site-packages', VENV])
     else:
         run_command(['virtualenv', '-q', VENV])
-    print 'done.'
-    print 'Installing pip in virtualenv...',
+    print('done.')
+    print('Installing pip in virtualenv...')
     if not run_command(['tools/with_venv.sh', 'easy_install',
                         'pip>1.0']).strip():
         die("Failed to install pip.")
-    print 'done.'
+    print('done.')
 
 
 def pip_install(*args):
@@ -182,7 +182,7 @@ def pip_install(*args):
 
 
 def install_dependencies(venv=VENV):
-    print 'Installing dependencies with pip (this can take a while)...'
+    print('Installing dependencies with pip (this can take a while)...')
 
     # First things first, make sure our venv has the latest pip and distribute.
     pip_install('pip')
@@ -221,7 +221,7 @@ def print_help():
 
     Also, make test will automatically use the virtualenv.
     """
-    print help
+    print(help)
 
 
 def parse_args():


### PR DESCRIPTION
Just the minimum of updates so that pip install will work on python3.
1. call the print function
2. exceptions should use `except IOError as e` not `except IOError, e`
3. don't call split on a bytestring  https://github.com/openstack/python-novaclient/pull/9/files#L2R179
4. update permissions token in makedirs "The syntax of 0o777 is for Python 2.6 and 3+. otherwise for the 2 series it is 0777" https://github.com/openstack/python-novaclient/pull/9/files#L0R106 L2R179
