### PR TITLE
Set requests to retry on ConnectionError

### DIFF
--- a/novaclient/client.py
+++ b/novaclient/client.py
@@ -30,6 +30,14 @@ from novaclient import exceptions
 from novaclient import service_catalog
 from novaclient import utils
 
+# set requests to automatically retry on ConnectionError
+if hasattr(requests, 'defaults'):
+    # requests < 1.0
+    requests.defaults.defaults['max_retries'] = 3
+elif hasattr(requests, 'adapters'):
+    # requests >= 1.0
+    requests.adapters.DEFAULT_RETRIES = 3
+
 
 class HTTPClient(object):
 


### PR DESCRIPTION
Try to prevent novaclient from throwing requests.ConnectionErrors with
unstable api servers. This is kind of ugly (especially since requests1.0 got rid of max_retries config in defaults), but it does seem work work well.

We frequently get ConnectionErrors from the rackspace api endpoints. I've found that increasing retries to 3 virtually eliminates them. Wrapping all novaclient (or pyrax) calls to retry on a requests.ConnectionError is kind of ugly, so I started inserting this block into modules where we use nova.
