### PR TITLE
Throw instance of exceptions.NoUniqueMatch and not the class

### DIFF
--- a/novaclient/base.py
+++ b/novaclient/base.py
@@ -192,7 +192,8 @@ class ManagerWithFind(Manager):
             msg = "No %s matching %s." % (self.resource_class.__name__, kwargs)
             raise exceptions.NotFound(404, msg)
         elif num_matches > 1:
-            raise exceptions.NoUniqueMatch
+            msg = "No unique %s matching %s" % (self.resource_class.__name__, kwargs)
+            raise exceptions.NoUniqueMatch(msg)
         else:
             return matches[0]
 


### PR DESCRIPTION
I think there is an error in line 195 in base.py: It seems that the class exceptions.NoUniqueMatch is thrown and not an instance of that class. This leads to an incomplete error message like "ERROR: <attribute 'message' of 'exceptions.BaseException' objects>".

We throw now an instance of exceptions.NoUniqueMatch with a explaining message.
