### PR TITLE
Fix for the issue python-novaclient-bug-1613105

### DIFF
--- a/novaclient/tests/functional/v2/legacy/test_extended_attributes.py
+++ b/novaclient/tests/functional/v2/legacy/test_extended_attributes.py
@@ -31,7 +31,7 @@ class TestExtAttrNovaClient(base.ClientTestBase):
         return server, volume
 
     def _release_volume(self, server, volume):
-        self.nova('volume-detach', params="%s %s" % (server.id, volume.id))
+        self.cinder.volumes.detach(volume.id)
         self.wait_for_volume_status(volume, 'available')
 
     def test_extended_server_attributes(self):

--- a/novaclient/tests/functional/v2/legacy/test_instances.py
+++ b/novaclient/tests/functional/v2/legacy/test_instances.py
@@ -66,5 +66,5 @@ class TestInstanceCLI(base.ClientTestBase):
         self.wait_for_volume_status(volume, 'in-use')
 
         # clean up on success
-        self.nova('volume-detach', params="%s %s" % (name, volume.id))
+        self.cinder.volumes.detach(volume.id)
         self.wait_for_volume_status(volume, 'available')


### PR DESCRIPTION
This issue is related the way function call is made clinder api is needed instead of nova api