### PR TITLE
Set stack extraction limit in _get_function_name() - reduce import time 10x

### DIFF
--- a/novaclient/api_versions.py
+++ b/novaclient/api_versions.py
@@ -345,7 +345,7 @@ def _get_function_name(func):
     #    ("im_class" property does not exist at that moment)
     #  we need to write own logic to obtain the full function name which
     #  include module name, owner name(optional) and just function name.
-    filename, _lineno, _name, line = traceback.extract_stack()[-4]
+    filename, _lineno, _name, line = traceback.extract_stack(limit=4)[-4]
     module, _file_extension = os.path.splitext(filename)
     module = module.replace("/", ".")
     if module.endswith(func.__module__):


### PR DESCRIPTION
API Versioning in Nova client uses stack extraction to retrieve function name. 
There is no limit set for the traceback.extract_stack() function call. 
Retrieval of the whole stack is pretty expensive operation.  
Setting the limit to required depth (4 in this case) reduces import time for `novaclient.v2.client` almost by 10 times (from 3 seconds to 0.4 second).

### Perftest

Before change:
```python
from time import perf_counter
start = perf_counter(); from novaclient.v2.client import Client; print(perf_counter() - start)
3.0430265600000004
```
After change
```python
from time import perf_counter
start = perf_counter(); from novaclient.v2.client import Client; print(perf_counter() - start)
0.42426275999999996
```

Profiling diagram:
![image](https://user-images.githubusercontent.com/41152092/148994343-4a667a8c-8016-420b-865f-b87e8bf44e33.png)
