### PR TITLE
typo - Nova CLI deprecation warning

### DIFF
--- a/novaclient/tests/unit/test_shell.py
+++ b/novaclient/tests/unit/test_shell.py
@@ -631,7 +631,7 @@ class ShellTest(utils.TestCase):
         )
         # We also expect to see the deprecation warning
         self.assertIn(
-            'nova CLI is deprecated and will be a removed in a future release',
+            'nova CLI is deprecated and will be removed in a future release',
             sys.stderr.getvalue(),
         )
 
@@ -769,7 +769,7 @@ class ShellTest(utils.TestCase):
         self.assertIn('ERROR (MyException): message\n', err)
         # We also expect to see the deprecation warning
         self.assertIn(
-            'nova CLI is deprecated and will be a removed in a future release',
+            'nova CLI is deprecated and will be removed in a future release',
             err,
         )
 


### PR DESCRIPTION
Typo in the nova CLI deprecation warning. 